### PR TITLE
Fixes an error when training wide_resnet50_2.

### DIFF
--- a/reshape.py
+++ b/reshape.py
@@ -52,7 +52,7 @@ def reshape_model(model, arch, num_classes):
 		print("=> reshaped GoogleNet fully-connected layer with:  " + str(model.fc))
 	
 	else:
-		print("classifier reshaping not supported for " + args.arch)
+		print("classifier reshaping not supported for " + arch)
 		print("model will retain default of 1000 output classes")
 
 	return model


### PR DESCRIPTION
Ran into this error when attempting to run training for wide_resnet50_2 as part of UC Berkeley MIDS program W251 class. Seems like a simple copy/paste accident or something, once I did this training proceeded as expected.

root@jtrobec-xavier-02:/jetson-inference/python/training/classification# time python3 train.py --epochs=100 --arch=wide_resnet50_2 --model-dir=models/plants data/PlantCLEF_Subset

Use GPU: 0 for training
=> dataset classes:  20 ['ash', 'beech', 'cattail', 'cedar', 'clover', 'cyprus', 'daisy', 'dandelion', 'dogwood', 'elm', 'fern', 'fig', 'fir', 'juniper', 'maple', 'poison_ivy', 'sweetgum', 'sycamore', 'trout_lily', 'tulip_tree']
=> using pre-trained model 'wide_resnet50_2'
Namespace(arch='wide_resnet50_2', batch_size=8, data='data/PlantCLEF_Subset', dist_backend='nccl', dist_url='tcp://224.66.41.62:23456', distributed=False, epochs=100, evaluate=False, gpu=0, lr=0.1, model_dir='models/plants', momentum=0.9, multiprocessing_distributed=False, pretrained=True, print_freq=10, rank=-1, resolution=299, resume='', seed=None, start_epoch=0, weight_decay=0.0001, workers=2, world_size=-1)
Traceback (most recent call last):
  File "train.py", line 507, in <module>
    main()
  File "train.py", line 135, in main
    main_worker(args.gpu, ngpus_per_node, args)
  File "train.py", line 206, in main_worker
    model = reshape_model(model, args.arch, num_classes)
  File "/jetson-inference/python/training/classification/reshape.py", line 55, in reshape_model
    print("classifier reshaping not supported for " + args.arch)
NameError: name 'args' is not defined